### PR TITLE
chore: upgrade Go to 1.25

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        go-version: ["1.23"]
+        go-version: ["^1.25.0", "^1.26.0"]
 
     name: Run Tests
     steps:

--- a/opentelemetry/go.mod
+++ b/opentelemetry/go.mod
@@ -1,6 +1,6 @@
 module github.com/razorpay/golib/opentelemetry
 
-go 1.23
+go 1.25
 
 require (
 	github.com/prometheus/client_golang v1.17.0


### PR DESCRIPTION
## Summary

- Bumps `go` directive in `opentelemetry/go.mod` from `1.23` → `1.25`
- Updates CI matrix in `.github/workflows/tests.yml` to `["^1.25.0", "^1.26.0"]`
- Ran `go mod tidy`; build gate (`go build ./...`) passes

## Test plan

- [ ] CI passes on this PR with the updated Go matrix
- [ ] No regressions in opentelemetry package tests (`run_tests.sh`)

Part of org-wide Go N-1 migration to Go 1.25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)